### PR TITLE
DEV: Fix JS acceptance test

### DIFF
--- a/test/javascripts/acceptance/staff-alias-composer-test.js.es6
+++ b/test/javascripts/acceptance/staff-alias-composer-test.js.es6
@@ -36,7 +36,7 @@ acceptance("Discourse Staff Alias", function (needs) {
     const composerActions = selectKit(".composer-actions");
 
     await visit("/t/internationalization-localization/280");
-    await click(".topic-timeline button.create");
+    await click("#topic-footer-buttons .create");
     await composerActions.expand();
 
     assert.equal(composerActions.rows().length, 5);


### PR DESCRIPTION
I noticed this flaky test when debugging the plugins tests failures in core PR https://github.com/discourse/discourse/pull/11726, but this is unrelated to changes in that PR.

The topic timeline controls on the right-hand side are hidden if the window width is below a certain threshold. So, if you don't make your window wide enough when running tests, the test fails because the reply button of the timeline is gone.

This PR changes the test so it uses the reply button at the bottom of the topic instead of the reply button of the timeline controls.