### PR TITLE
DEV: Update plugin following core discourse-presence changes

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+2.8.0.beta6: ef60ee2db833f0eb3c44a605b5aeb60d7cae8e6c

--- a/assets/javascripts/discourse/initializers/discourse-staff-alias.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-staff-alias.js.es6
@@ -49,6 +49,30 @@ function initialize(api) {
       }
     });
 
+    api.modifyClass("component:composer-presence-display", {
+      @discourseComputed(
+        "model.replyingToTopic",
+        "model.editingPost",
+        "model.whisper",
+        "model.composerOpened",
+        "isDestroying",
+        "model.isReplyAsStaffAlias"
+      )
+      state(
+        replyingToTopic,
+        editingPost,
+        whisper,
+        composerOpen,
+        isDestroying,
+        isReplyAsStaffAlias
+      ) {
+        if (isReplyAsStaffAlias) {
+          return "whisper";
+        }
+        return this._super(...arguments);
+      },
+    });
+
     api.modifyClass("component:composer-actions", {
       pluginId: PLUGIN_ID,
       toggleReplyAsStaffAliasSelected(options, model) {
@@ -73,9 +97,7 @@ function initialize(api) {
       @observes("isReplyAsStaffAlias")
       _updateUser() {
         if (this.isReplyAsStaffAlias) {
-          const props = {
-            _presenceStaffOnly: true,
-          };
+          const props = {};
 
           if (this.topic) {
             props._originalUser = this.user;
@@ -84,9 +106,7 @@ function initialize(api) {
 
           this.setProperties(props);
         } else {
-          const props = {
-            _presenceStaffOnly: false,
-          };
+          const props = {};
 
           if (this._originalUser) {
             props.user = this.get("_originalUser");


### PR DESCRIPTION
This plugin hides a user's presence from non-staff when they're replying as a staff alias. This commit updates that logic to work with the latest core changes, and also adds a JS test for this override.