### PR TITLE
FIX: Allow wiki and post_type revisions on staff alias user post.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -173,7 +173,11 @@ after_initialize do
         self.errors.add(:base, I18n.t("post_revisions.errors.cannot_edit_whisper_as_staff_alias"))
       end
     elsif self.post.user_id == SiteSetting.get(:staff_alias_user_id) && User.human_user_id?(self.user_id)
-      self.errors.add(:base, I18n.t("post_revisions.errors.cannot_edit_aliased_post_as_staff"))
+      if (self.modifications.keys & ["wiki", "post_type"]).present? && DiscourseStaffAlias.user_allowed?(self.user)
+        self.user_id = SiteSetting.get(:staff_alias_user_id)
+      else
+        self.errors.add(:base, I18n.t("post_revisions.errors.cannot_edit_aliased_post_as_staff"))
+      end
     end
   end
 

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -6,6 +6,28 @@ describe PostRevision do
   fab!(:user) { Fabricate(:user) }
   fab!(:post_revision) { Fabricate(:post_revision) }
 
+  fab!(:admin) do
+    user = Fabricate(:admin)
+    group = Group.find(Group::AUTO_GROUPS[:staff])
+    group.add(user)
+    user
+  end
+
+  before do
+    SiteSetting.set(:staff_alias_allowed_groups, Group::AUTO_GROUPS[:staff].to_s)
+    SiteSetting.set(:staff_alias_username, 'staff_alias_user')
+    SiteSetting.set(:staff_alias_enabled, true)
+  end
+
+  it 'does not allow users that are not in staff alias allowed group to edit posts made by staff alias user' do
+    SiteSetting.set(:staff_alias_allowed_groups, "somegroupname")
+
+    post = Fabricate(:post, user: DiscourseStaffAlias.alias_user)
+    post_revision = Fabricate.build(:post_revision, post: post, user: admin)
+
+    expect(post_revision.valid?).to eq(false)
+  end
+
   it 'cleans up users_posts_links association on destroy' do
     link = ::DiscourseStaffAlias::UsersPostRevisionsLink.create!(
       user: user,
@@ -22,12 +44,35 @@ describe PostRevision do
   end
 
   it 'allows non human users to edit posts made by the staff alias user' do
-    SiteSetting.set(:staff_alias_username, 'staff_alias_user')
-    SiteSetting.set(:staff_alias_enabled, true)
-
-    post = Fabricate(:post, user: User.find(SiteSetting.get(:staff_alias_user_id)))
+    post = Fabricate(:post, user: DiscourseStaffAlias.alias_user)
     post_revision = Fabricate.build(:post_revision, post: post, user: Discourse.system_user)
 
     expect(post_revision.valid?).to eq(true)
+  end
+
+  it 'switches revision user to staff alias user when changing wiki status of post made as staff alias user' do
+    post = Fabricate(:post, user: DiscourseStaffAlias.alias_user, wiki: false)
+
+    post_revision = Fabricate.build(:post_revision,
+      post: post,
+      user: admin,
+      modifications: { "wiki" => [false, true] }
+    )
+
+    expect(post_revision.valid?).to eq(true)
+    expect(post_revision.user_id).to eq(SiteSetting.get(:staff_alias_user_id))
+  end
+
+  it 'switches revision user to staff alias user when changing post_type of post made as staff alias user' do
+    post = Fabricate(:post, user: DiscourseStaffAlias.alias_user, post_type: Post.types[:regular])
+
+    post_revision = Fabricate.build(:post_revision,
+      post: post,
+      user: admin,
+      modifications: { "post_type" => [Post.types[:regular], Post.types[:moderator_action]] }
+    )
+
+    expect(post_revision.valid?).to eq(true)
+    expect(post_revision.user_id).to eq(SiteSetting.get(:staff_alias_user_id))
   end
 end


### PR DESCRIPTION
Previously, a user that is allowed to post as a staff alias user would
not be able to change the post type or wiki status of the post. This
commit fixes that by automatically revising the post as the staff alias
user if the user making the revision is allowed to post as a staff alias
user.