### PR TITLE
FEATURE: Allow posts to change ownership to the staff alias user

### DIFF
--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -86,19 +86,20 @@ describe PostRevision do
   end
 
   it "switches revision user to staff alias user when changing user_id of post to staff alias user" do
+    another_user = Fabricate(:user)
     post = Fabricate(:post, user: user, post_type: Post.types[:regular])
 
     post_revision =
       Fabricate.build(
         :post_revision,
         post: post,
-        user: DiscourseStaffAlias.alias_user,
+        user: another_user,
         modifications: {
           "user_id" => [user.id, DiscourseStaffAlias.alias_user.id],
         },
       )
 
     expect(post_revision.valid?).to eq(true)
-    expect(post_revision.user_id).to eq(SiteSetting.get(:staff_alias_user_id))
+    expect(post_revision.user_id).to eq(another_user.id)
   end
 end

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -93,7 +93,9 @@ describe PostRevision do
         :post_revision,
         post: post,
         user: DiscourseStaffAlias.alias_user,
-        modifications: { "user_id" => [user.id, DiscourseStaffAlias.alias_user.id] },
+        modifications: {
+          "user_id" => [user.id, DiscourseStaffAlias.alias_user.id],
+        },
       )
 
     expect(post_revision.valid?).to eq(true)

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -84,4 +84,19 @@ describe PostRevision do
     expect(post_revision.valid?).to eq(true)
     expect(post_revision.user_id).to eq(SiteSetting.get(:staff_alias_user_id))
   end
+
+  it "switches revision user to staff alias user when changing user_id of post to staff alias user" do
+    post = Fabricate(:post, user: user, post_type: Post.types[:regular])
+
+    post_revision =
+      Fabricate.build(
+        :post_revision,
+        post: post,
+        user: DiscourseStaffAlias.alias_user,
+        modifications: { "user_id" => [user.id, DiscourseStaffAlias.alias_user.id] },
+      )
+
+    expect(post_revision.valid?).to eq(true)
+    expect(post_revision.user_id).to eq(SiteSetting.get(:staff_alias_user_id))
+  end
 end

--- a/spec/models/post_revisor.rb
+++ b/spec/models/post_revisor.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PostRevisor do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:post) { Fabricate(:post, user: user) }
+
+  context "when post_edited" do
+    fab!(:moderator) { Fabricate(:moderator) }
+    let(:post_revisor) { PostRevisor.new(post) }
+
+    before do
+      SiteSetting.set(:staff_alias_allowed_groups, Group::AUTO_GROUPS[:staff].to_s)
+      SiteSetting.set(:staff_alias_username, "staff_alias_user")
+      SiteSetting.set(:staff_alias_enabled, true)
+    end
+
+    context "when it is a user_id modification" do
+      it "creates a users_posts_link record when the post's ownership changes to staff_alias_user" do
+        post_revisor.revise!(
+          moderator,
+          {
+            raw: post.raw,
+            user_id: DiscourseStaffAlias.alias_user.id,
+            edit_reason: "Ownership transferred",
+          },
+          force_new_version: true,
+        )
+
+        expect(DiscourseStaffAlias::UsersPostsLink.last).to have_attributes(
+          user_id: user.id,
+          post_id: post.id,
+        )
+      end
+
+      it "does not create a users_posts_link record when the post's ownership changes to not the staff_alias_user" do
+        expect {
+          post_revisor.revise!(
+            moderator,
+            { raw: post.raw, user_id: moderator.id, edit_reason: "Ownership transferred" },
+            force_new_version: true,
+          )
+        }.to not_change { DiscourseStaffAlias::UsersPostsLink.count }
+      end
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe Post do
   fab!(:user) { Fabricate(:user) }
-  fab!(:post) { Fabricate(:post, user: user) }
+  fab!(:post) { Fabricate(:post) }
 
   it "cleans up users_posts_links association on destroy" do
     link = ::DiscourseStaffAlias::UsersPostsLink.create!(user: user, post: post)
@@ -14,45 +14,5 @@ describe Post do
     post.destroy!
 
     expect(DiscourseStaffAlias::UsersPostsLink.exists?(post_id: post.id)).to eq(false)
-  end
-
-  context "when post_edited" do
-    fab!(:moderator) { Fabricate(:moderator) }
-    let(:post_revisor) { PostRevisor.new(post) }
-
-    before do
-      SiteSetting.set(:staff_alias_allowed_groups, Group::AUTO_GROUPS[:staff].to_s)
-      SiteSetting.set(:staff_alias_username, "staff_alias_user")
-      SiteSetting.set(:staff_alias_enabled, true)
-    end
-
-    context "when is a user_id modification" do
-      it "creates a users_posts_link when the post changes to staff_alias_user" do
-        post_revisor.revise!(
-          moderator,
-          {
-            raw: post.raw,
-            user_id: DiscourseStaffAlias.alias_user.id,
-            edit_reason: "Ownership transferred",
-          },
-          force_new_version: true,
-        )
-
-        expect(DiscourseStaffAlias::UsersPostsLink.last).to have_attributes(
-          user_id: user.id,
-          post_id: post.id,
-        )
-      end
-
-      it "does not create a users_posts_link when the post changes to not the staff_alias_user" do
-        expect {
-          post_revisor.revise!(
-            moderator,
-            { raw: post.raw, user_id: moderator.id, edit_reason: "Ownership transferred" },
-            force_new_version: true,
-          )
-        }.to not_change { DiscourseStaffAlias::UsersPostsLink.count }
-      end
-    end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe Post do
   fab!(:user) { Fabricate(:user) }
-  fab!(:post) { Fabricate(:post) }
+  fab!(:post) { Fabricate(:post, user: user) }
 
   it "cleans up users_posts_links association on destroy" do
     link = ::DiscourseStaffAlias::UsersPostsLink.create!(user: user, post: post)
@@ -14,5 +14,45 @@ describe Post do
     post.destroy!
 
     expect(DiscourseStaffAlias::UsersPostsLink.exists?(post_id: post.id)).to eq(false)
+  end
+
+  context "when post_edited" do
+    fab!(:moderator) { Fabricate(:moderator) }
+    let(:post_revisor) { PostRevisor.new(post) }
+
+    before do
+      SiteSetting.set(:staff_alias_allowed_groups, Group::AUTO_GROUPS[:staff].to_s)
+      SiteSetting.set(:staff_alias_username, "staff_alias_user")
+      SiteSetting.set(:staff_alias_enabled, true)
+    end
+
+    context "when is a user_id modification" do
+      it "creates a users_posts_link when the post changes to staff_alias_user" do
+        post_revisor.revise!(
+          moderator,
+          {
+            raw: post.raw,
+            user_id: DiscourseStaffAlias.alias_user.id,
+            edit_reason: "Ownership transferred",
+          },
+          force_new_version: true,
+        )
+
+        expect(DiscourseStaffAlias::UsersPostsLink.last).to have_attributes(
+          user_id: user.id,
+          post_id: post.id,
+        )
+      end
+
+      it "does not create a users_posts_link when the post changes to not the staff_alias_user" do
+        expect {
+          post_revisor.revise!(
+            moderator,
+            { raw: post.raw, user_id: moderator.id, edit_reason: "Ownership transferred" },
+            force_new_version: true,
+          )
+        }.to not_change { DiscourseStaffAlias::UsersPostsLink.count }
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently for this plugin, we only allow 2 types of post modifications to be done to a post
- if the post type changes e.g. from regular to whisper
- or if the post is a wiki

Additionally, posts will add a `DiscourseStaffAlias::UsersPostsLink` which will indicate the post's owner. e.g. `staff_alias_username` is `derpy.mcderpface`, and the post was written by `tomtom`. This is done on creation of a post.

<img width="250" alt="Screenshot 2023-03-08 at 1 20 07 AM" src="https://user-images.githubusercontent.com/1555215/223499361-e2170b48-eb9a-4842-b515-46d510d4f84c.png">

This PR allows an **existing post** to be modified and change its ownership to a staff_alias_user, and also adds the original creator of the post into `DiscourseStaffAlias::UsersPostsLink` to show that spy user similar to the screenshot above.


https://user-images.githubusercontent.com/1555215/223503875-a5e5a355-61dd-43f2-b48a-49f9ebb9dfa6.mov

