### PR TITLE
FIX: Events should not return

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -184,7 +184,7 @@ after_initialize do
 
   on(:post_edited) do |post, _topic_changed, revisor|
     post_revision = revisor.post_revision
-    return if post_revision.nil?
+    next if post_revision.nil?
 
     alias_user_id = SiteSetting.get(:staff_alias_user_id)
 

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -102,4 +102,14 @@ describe PostRevision do
     expect(post_revision.valid?).to eq(true)
     expect(post_revision.user_id).to eq(another_user.id)
   end
+
+  it "does not error out if no post revisions" do
+    post = Fabricate(:post, user: user, post_type: Post.types[:regular])
+    revisor = PostRevisor.new(post)
+
+    expect { DiscourseEvent.trigger(:post_edited, post, false, revisor) }.not_to raise_error
+    expect { DiscourseEvent.trigger(:post_edited, post, false, revisor) }.not_to change {
+      DiscourseStaffAlias::UsersPostRevisionsLink.count
+    }
+  end
 end


### PR DESCRIPTION
The `on(:post_edited)` block was `return`ing, which it shouldn't. This resulted in users being unable to edit their posts, as seen on [Meta](https://meta.discourse.org/t/after-editing-saving-bar-is-stuck/259347). This bug was introduced in https://github.com/discourse/discourse-staff-alias/pull/47