### PR TITLE
DEV: Ensure a post is edited if event is triggered

### DIFF
--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -106,6 +106,7 @@ describe PostRevision do
   it "does not error out if no post revisions" do
     post = Fabricate(:post, user: user, post_type: Post.types[:regular])
     revisor = PostRevisor.new(post)
+    revisor.revise!(post.user, { raw: "post revisions should be made if there's an edit" })
 
     expect { DiscourseEvent.trigger(:post_edited, post, false, revisor) }.not_to raise_error
     expect { DiscourseEvent.trigger(:post_edited, post, false, revisor) }.not_to change {


### PR DESCRIPTION
This test was failing because of https://github.com/discourse/discourse-group-tracker/blob/3c53c7ffbc9373ecac2a755341a635448e62f4bc/plugin.rb#L176-L182. This PR adds a `previous_change` to a post by making sure there was a revision.