### PR TITLE
DEV: Refresh auto groups in specs

### DIFF
--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -32,6 +32,7 @@ describe PostsController do
     SiteSetting.set(:staff_alias_username, "some_alias")
     SiteSetting.set(:staff_alias_enabled, true)
     SiteSetting.set(:editing_grace_period, 0)
+    Group.refresh_automatic_groups!
   end
 
   describe "#update" do


### PR DESCRIPTION
This PR https://github.com/discourse/discourse/pull/21493 is having troubles with the topic controller specs b/c the guardian has changed and now relies on users' group_ids. You have to refresh_automatic_groups in specs for this to work properly. 🤷 