### PR TITLE
FIX: Allow topics created by staff alias to have their tags edited

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -173,7 +173,7 @@ after_initialize do
       end
     elsif self.post.user_id == SiteSetting.get(:staff_alias_user_id) &&
           User.human_user_id?(self.user_id)
-      if (self.modifications.keys & %w[wiki post_type user_id title]).present? &&
+      if (self.modifications.keys & %w[wiki post_type user_id title tags]).present? &&
            DiscourseStaffAlias.user_allowed?(self.user)
         self.user_id = SiteSetting.get(:staff_alias_user_id)
       else

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -121,6 +121,15 @@ describe PostRevision do
     expect(post_revision.valid?).to eq(true)
   end
 
+  it "allows tag revisions in topics by staff alias users" do
+    post = Fabricate(:post, user: DiscourseStaffAlias.alias_user, post_type: Post.types[:regular])
+
+    post_revision =
+      Fabricate.build(:post_revision, post: post, user: admin, modifications: { "tags" => "x" })
+
+    expect(post_revision.valid?).to eq(true)
+  end
+
   it "does not error out if no post revisions" do
     post = Fabricate(:post, user: user, post_type: Post.types[:regular])
     revisor = PostRevisor.new(post)


### PR DESCRIPTION
Right now when modifying topic tags for a topic created using staff alias, we get a 422.

<img width="786" alt="Screenshot 2023-10-20 at 9 43 11 PM" src="https://github.com/discourse/discourse-staff-alias/assets/1555215/da7fd783-b0c8-40d2-bc69-4342dceb1721">

This commit allows users who can perform as the staff alias user to modify the topic's tags.