### PR TITLE
FIX: Convert type in whisper params

### DIFF
--- a/lib/discourse_staff_alias/posts_controller_extension.rb
+++ b/lib/discourse_staff_alias/posts_controller_extension.rb
@@ -14,7 +14,7 @@ module DiscourseStaffAlias
              ) == "true"
           existing_user = controller.current_user
 
-          if !DiscourseStaffAlias.user_allowed?(existing_user) || params[:whisper]
+          if !DiscourseStaffAlias.user_allowed?(existing_user) || params[:whisper].to_s == "true"
             raise Discourse::InvalidAccess
           end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -106,6 +106,7 @@ describe PostsController do
                topic_id: post_1.topic_id,
                reply_to_post_number: 1,
                as_staff_alias: true,
+               whisper: "false",
              }
 
         expect(response.status).to eq(200)


### PR DESCRIPTION
We may send a request with `whisper: "false"``, which will be judged as InvalidAccess. This bug causes StaffAlias users to be unable to reply to any posts other than the OP's.

Thanks @fokx for finding this.

meta: https://meta.discourse.org/t/discourse-staff-alias/156202/25?u=lhc_fl