### PR TITLE
DEV: pin plugin for discourse < 3.4.0.beta3-dev

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta3-dev: 170d6e5372ba3067832a7a52730a16131d4ccfc1
 < 3.4.0.beta1-dev: ff412dfb1a65c9c8bff4bc5a008592e4a6de9e17
 < 3.3.0.beta1-dev: 9edf642b0eeea6dc51b026d6e4de6ae87debe7ac
 3.1.0.beta3: 291999b5f2a876f31a98c78befbf30933e405c8f


### PR DESCRIPTION
So we can merge https://github.com/discourse/discourse/pull/29235 and then update this plugin's code