### PR TITLE
DEV: Added compatibility with the Glimmer Post Stream

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.5.0.beta8-dev: faacab2a6d632d2162c90a258002fee2d3be3c1f
 < 3.5.0.beta5-dev: c88da1b11243f9cc16b4dc5d5a3476f04ee4874b
 < 3.5.0.beta1-dev: b8a7986d5dfffd1b4e345def2e3a1de0de63ecb3
 < 3.4.0.beta3-dev: 170d6e5372ba3067832a7a52730a16131d4ccfc1

--- a/assets/javascripts/discourse/initializers/discourse-staff-alias.js
+++ b/assets/javascripts/discourse/initializers/discourse-staff-alias.js
@@ -117,24 +117,23 @@ function initialize(api) {
     api.serializeOnUpdate("as_staff_alias", "isReplyAsStaffAlias");
     api.serializeToTopic("as_staff_alias", "isReplyAsStaffAlias");
 
-    api.includePostAttributes("aliased_username");
-    api.includePostAttributes("is_staff_aliased");
+    api.addTrackedPostProperties("aliased_username", "is_staff_aliased");
 
-    api.addPosterIcon((cfs, attrs) => {
-      if (attrs.is_staff_aliased) {
+    api.addPosterIcon((cfs, post) => {
+      if (post.is_staff_aliased) {
         const props = {
           icon: "user-secret",
           className: "user-title",
         };
 
-        if (attrs.aliased_username) {
-          props.text = attrs.aliased_username;
+        if (post.aliased_username) {
+          props.text = post.aliased_username;
 
           props.title = i18n("discourse_staff_alias.poster_icon_title", {
-            username: attrs.aliased_username,
+            username: post.aliased_username,
           });
 
-          props.url = `/u/${attrs.aliased_username}`;
+          props.url = `/u/${post.aliased_username}`;
         } else {
           props.text = i18n("discourse_staff_alias.aliased_user_deleted");
         }


### PR DESCRIPTION
This PR updates the discourse-staff-alias plugin to ensure compatibility with the new Glimmer Post Stream. Key changes include:

- Replacing `includePostAttributes` with `addTrackedPostProperties` to align with the updated post stream API.
- Refactoring and renaming variables in `addPosterIcon` for improved clarity and maintainability.
- Standardizing parameter usage and simplifying logic for consistency.
- Updates `.discourse-compatibility` to add support for Discourse 3.5.0.beta8-dev.

These changes improve code quality and maintain compatibility with the latest Discourse core updates.