### PR TITLE
DEV: Replace usage of `any` with `some` in `staff-alias-composer-test`

### DIFF
--- a/test/javascripts/acceptance/staff-alias-composer-test.js
+++ b/test/javascripts/acceptance/staff-alias-composer-test.js
@@ -8,7 +8,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { _clearSnapshots } from "select-kit/components/composer-actions";
 
-const discoursePresenceInstalled = Object.keys(requirejs.entries).any((name) =>
+const discoursePresenceInstalled = Object.keys(requirejs.entries).some((name) =>
   name.includes("/discourse-presence/")
 );
 const testIfPresenceInstalled = discoursePresenceInstalled ? test : skip;


### PR DESCRIPTION
Update the `discoursePresenceInstalled` check to use `some` instead of `any` to resolve the Ember deprecation