### PR TITLE
DEV: Update composer actions to use DMenu transformer API

### DIFF
--- a/assets/javascripts/discourse/connectors/composer-action-after/reply-as-staff-alias-icon.gjs
+++ b/assets/javascripts/discourse/connectors/composer-action-after/reply-as-staff-alias-icon.gjs
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-classic-components */
 import Component from "@ember/component";
 import { classNames, tagName } from "@ember-decorators/component";
-import icon from "discourse/helpers/d-icon";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 @tagName("")
 @classNames("composer-action-after-outlet", "reply-as-staff-alias-icon")
@@ -12,7 +12,7 @@ export default class ReplyAsStaffAliasIcon extends Component {
 
   <template>
     {{#if this.model.isReplyAsStaffAlias}}
-      <span class="reply-as-staff-alias-icon">{{icon "user-secret"}}</span>
+      <span class="reply-as-staff-alias-icon">{{dIcon "user-secret"}}</span>
     {{/if}}
   </template>
 }

--- a/assets/javascripts/discourse/connectors/revision-user-details-after/aliased-staff-user-details.gjs
+++ b/assets/javascripts/discourse/connectors/revision-user-details-after/aliased-staff-user-details.gjs
@@ -2,7 +2,7 @@
 import Component from "@ember/component";
 import { LinkTo } from "@ember/routing";
 import { classNames, tagName } from "@ember-decorators/component";
-import icon from "discourse/helpers/d-icon";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 @tagName("")
@@ -24,12 +24,12 @@ export default class AliasedStaffUserDetails extends Component {
               username=this.model.aliased_username
             }}
           >
-            <span>({{icon "user-secret"}}
+            <span>({{dIcon "user-secret"}}
               {{this.model.aliased_username}})</span>
           </LinkTo>
         {{else}}
           <span>
-            ({{icon "user-secret"}}
+            ({{dIcon "user-secret"}}
             {{i18n "discourse_staff_alias.aliased_user_deleted"}})
           </span>
         {{/if}}

--- a/assets/javascripts/discourse/initializers/discourse-staff-alias.js
+++ b/assets/javascripts/discourse/initializers/discourse-staff-alias.js
@@ -3,51 +3,68 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { CREATE_TOPIC, EDIT, REPLY } from "discourse/models/composer";
 import { i18n } from "discourse-i18n";
 
-const PLUGIN_ID = "discourse-staff-alias";
-
 function initialize(api) {
   const currentUser = api.getCurrentUser();
 
   if (currentUser?.can_act_as_staff_alias) {
-    api.modifySelectKit("composer-actions").prependContent((component) => {
-      if (component.action === CREATE_TOPIC) {
-        return [
-          {
-            name: i18n(
-              "composer.composer_actions.as_staff_alias.create_topic.label"
-            ),
-            description: i18n(
-              "composer.composer_actions.as_staff_alias.create_topic.desc"
-            ),
-            icon: "user-secret",
-            id: "toggle_reply_as_staff_alias",
-          },
-        ];
+    api.registerValueTransformer("composer-actions-content", ({ value, context }) => {
+      const { action, topic, post, composerModel } = context;
+
+      if (action === CREATE_TOPIC) {
+        value.unshift({
+          name: i18n(
+            "composer.composer_actions.as_staff_alias.create_topic.label"
+          ),
+          description: i18n(
+            "composer.composer_actions.as_staff_alias.create_topic.desc"
+          ),
+          icon: "user-secret",
+          id: "toggle_reply_as_staff_alias",
+        });
       }
+
+      const site = api.container.lookup("service:site");
+
+      if (
+        topic?.details?.staff_alias_can_create_post &&
+        (action === REPLY ||
+          (action === EDIT &&
+            post?.post_type !== site?.post_types?.whisper &&
+            !post?.is_staff_aliased))
+      ) {
+        value.push({
+          name: i18n(
+            `composer.composer_actions.as_staff_alias.${action}.label`
+          ),
+          description: i18n(
+            `composer.composer_actions.as_staff_alias.${action}.desc`
+          ),
+          icon: "user-secret",
+          id: "toggle_reply_as_staff_alias",
+        });
+      }
+
+      return value;
     });
 
-    api.modifySelectKit("composer-actions").appendContent((component) => {
-      if (
-        component.topic?.details?.staff_alias_can_create_post &&
-        (component.action === REPLY ||
-          (component.action === EDIT &&
-            component.get("post.post_type") !==
-              component.get("site.post_types.whisper") &&
-            !component.get("post.is_staff_aliased")))
-      ) {
-        return [
-          {
-            name: i18n(
-              `composer.composer_actions.as_staff_alias.${component.action}.label`
-            ),
-            description: i18n(
-              `composer.composer_actions.as_staff_alias.${component.action}.desc`
-            ),
-            icon: "user-secret",
-            id: "toggle_reply_as_staff_alias",
-          },
-        ];
+    api.registerBehaviorTransformer("composer-actions-on-select", ({ context, next }) => {
+      const { actionId, model } = context;
+
+      if (actionId === "toggle_reply_as_staff_alias") {
+        model.toggleProperty("replyAsStaffAlias");
+        if (model.whisper) {
+          model.set("whisper", false);
+        }
+        return;
       }
+
+      if (actionId === "toggle_whisper") {
+        if (model.replyAsStaffAlias) {
+          model.set("replyAsStaffAlias", false);
+        }
+      }
+
+      next();
     });
 
     api.modifyClass(
@@ -65,24 +82,6 @@ function initialize(api) {
           }
         }
     );
-
-    api.modifyClass("component:composer-actions", {
-      pluginId: PLUGIN_ID,
-
-      toggleReplyAsStaffAliasSelected(options, model) {
-        model.toggleProperty("replyAsStaffAlias");
-        if (model.whisper) {
-          model.set("whisper", false);
-        }
-      },
-
-      toggleWhisperSelected(options, model) {
-        this._super(...arguments);
-        if (model.replyAsStaffAlias) {
-          model.set("replyAsStaffAlias", false);
-        }
-      },
-    });
 
     api.modifyClass(
       "model:composer",

--- a/assets/javascripts/discourse/initializers/discourse-staff-alias.js
+++ b/assets/javascripts/discourse/initializers/discourse-staff-alias.js
@@ -7,65 +7,71 @@ function initialize(api) {
   const currentUser = api.getCurrentUser();
 
   if (currentUser?.can_act_as_staff_alias) {
-    api.registerValueTransformer("composer-actions-content", ({ value, context }) => {
-      const { action, topic, post } = context;
+    api.registerValueTransformer(
+      "composer-actions-content",
+      ({ value, context }) => {
+        const { action, topic, post } = context;
 
-      if (action === CREATE_TOPIC) {
-        value.unshift({
-          name: i18n(
-            "composer.composer_actions.as_staff_alias.create_topic.label"
-          ),
-          description: i18n(
-            "composer.composer_actions.as_staff_alias.create_topic.desc"
-          ),
-          icon: "user-secret",
-          id: "toggle_reply_as_staff_alias",
-        });
-      }
-
-      const site = api.container.lookup("service:site");
-
-      if (
-        topic?.details?.staff_alias_can_create_post &&
-        (action === REPLY ||
-          (action === EDIT &&
-            post?.post_type !== site?.post_types?.whisper &&
-            !post?.is_staff_aliased))
-      ) {
-        value.push({
-          name: i18n(
-            `composer.composer_actions.as_staff_alias.${action}.label`
-          ),
-          description: i18n(
-            `composer.composer_actions.as_staff_alias.${action}.desc`
-          ),
-          icon: "user-secret",
-          id: "toggle_reply_as_staff_alias",
-        });
-      }
-
-      return value;
-    });
-
-    api.registerBehaviorTransformer("composer-actions-on-select", ({ context, next }) => {
-      const { actionId, model } = context;
-
-      if (actionId === "toggle_reply_as_staff_alias") {
-        model.toggleProperty("replyAsStaffAlias");
-        if (model.whisper) {
-          model.set("whisper", false);
+        if (action === CREATE_TOPIC) {
+          value.unshift({
+            name: i18n(
+              "composer.composer_actions.as_staff_alias.create_topic.label"
+            ),
+            description: i18n(
+              "composer.composer_actions.as_staff_alias.create_topic.desc"
+            ),
+            icon: "user-secret",
+            id: "toggle_reply_as_staff_alias",
+          });
         }
-        return;
-      }
 
-      if (actionId === "toggle_whisper") {
-        if (model.replyAsStaffAlias) {
-          model.set("replyAsStaffAlias", false);
+        const site = api.container.lookup("service:site");
+
+        if (
+          topic?.details?.staff_alias_can_create_post &&
+          (action === REPLY ||
+            (action === EDIT &&
+              post?.post_type !== site?.post_types?.whisper &&
+              !post?.is_staff_aliased))
+        ) {
+          value.push({
+            name: i18n(
+              `composer.composer_actions.as_staff_alias.${action}.label`
+            ),
+            description: i18n(
+              `composer.composer_actions.as_staff_alias.${action}.desc`
+            ),
+            icon: "user-secret",
+            id: "toggle_reply_as_staff_alias",
+          });
         }
-      }
 
-      next();
-    });
+        return value;
+      }
+    );
+
+    api.registerBehaviorTransformer(
+      "composer-actions-on-select",
+      ({ context, next }) => {
+        const { actionId, model } = context;
+
+        if (actionId === "toggle_reply_as_staff_alias") {
+          model.toggleProperty("replyAsStaffAlias");
+          if (model.whisper) {
+            model.set("whisper", false);
+          }
+          return;
+        }
+
+        if (actionId === "toggle_whisper") {
+          if (model.replyAsStaffAlias) {
+            model.set("replyAsStaffAlias", false);
+          }
+        }
+
+        next();
+      }
+    );
 
     api.modifyClass(
       "component:composer-actions",

--- a/assets/javascripts/discourse/initializers/discourse-staff-alias.js
+++ b/assets/javascripts/discourse/initializers/discourse-staff-alias.js
@@ -8,7 +8,7 @@ function initialize(api) {
 
   if (currentUser?.can_act_as_staff_alias) {
     api.registerValueTransformer("composer-actions-content", ({ value, context }) => {
-      const { action, topic, post, composerModel } = context;
+      const { action, topic, post } = context;
 
       if (action === CREATE_TOPIC) {
         value.unshift({

--- a/assets/javascripts/discourse/initializers/discourse-staff-alias.js
+++ b/assets/javascripts/discourse/initializers/discourse-staff-alias.js
@@ -68,6 +68,65 @@ function initialize(api) {
     });
 
     api.modifyClass(
+      "component:composer-actions",
+      (Superclass) =>
+        class extends Superclass {
+          toggleReplyAsStaffAliasSelected(options, model) {
+            model.toggleProperty("replyAsStaffAlias");
+            if (model.whisper) {
+              model.set("whisper", false);
+            }
+          }
+
+          toggleWhisperSelected(options, model) {
+            if (model.replyAsStaffAlias) {
+              model.set("replyAsStaffAlias", false);
+            }
+            super.toggleWhisperSelected(options, model);
+          }
+        }
+    );
+
+    api.modifySelectKit("composer-actions").appendContent((options) => {
+      const items = [];
+      const site = api.container.lookup("service:site");
+
+      if (options.action === CREATE_TOPIC) {
+        items.push({
+          name: i18n(
+            "composer.composer_actions.as_staff_alias.create_topic.label"
+          ),
+          description: i18n(
+            "composer.composer_actions.as_staff_alias.create_topic.desc"
+          ),
+          icon: "user-secret",
+          id: "toggle_reply_as_staff_alias",
+        });
+      }
+
+      if (
+        options.topic?.details?.staff_alias_can_create_post &&
+        (options.action === REPLY ||
+          (options.action === EDIT &&
+            options.post?.post_type !== site?.post_types?.whisper &&
+            !options.post?.is_staff_aliased))
+      ) {
+        items.push({
+          name: i18n(
+            `composer.composer_actions.as_staff_alias.${options.action}.label`
+          ),
+          description: i18n(
+            `composer.composer_actions.as_staff_alias.${options.action}.desc`
+          ),
+          icon: "user-secret",
+          id: "toggle_reply_as_staff_alias",
+        });
+      }
+
+      return items;
+    });
+
+    api.modifyClass(
       "component:composer-presence-display",
       (ComposerPresenceDisplayComponent) =>
         class extends ComposerPresenceDisplayComponent {

--- a/test/javascripts/acceptance/staff-alias-composer-test.js
+++ b/test/javascripts/acceptance/staff-alias-composer-test.js
@@ -6,13 +6,49 @@ import { _clearSnapshots } from "discourse/select-kit/components/composer-action
 import topicFixtures from "discourse/tests/fixtures/topic";
 import { presentUserIds } from "discourse/tests/helpers/presence-pretender";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
-import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const discoursePresenceInstalled = Object.keys(requirejs.entries).some((name) =>
   name.includes("/discourse-presence/")
 );
 const testIfPresenceInstalled = discoursePresenceInstalled ? test : skip;
 let staffAliasCanCreatePost = true;
+
+function composerActionsDropdown() {
+  return {
+    async expand() {
+      await click(".composer-actions-trigger");
+    },
+    async selectRowByValue(value) {
+      await click(`[data-action-id='${value}']`);
+    },
+    rowByValue(value) {
+      const el = document.querySelector(
+        `.composer-actions-dropdown [data-action-id='${value}']`
+      );
+      return {
+        exists() {
+          return !!el;
+        },
+      };
+    },
+    rows() {
+      return document.querySelectorAll(
+        ".composer-actions-dropdown [data-action-id]"
+      );
+    },
+    rowByIndex(index) {
+      const rows = document.querySelectorAll(
+        ".composer-actions-dropdown [data-action-id]"
+      );
+      const row = rows[index];
+      return {
+        value() {
+          return row ? row.dataset.actionId : null;
+        },
+      };
+    },
+  };
+}
 
 acceptance("Discourse Staff Alias", function (needs) {
   needs.user({ can_act_as_staff_alias: true });
@@ -48,7 +84,7 @@ acceptance("Discourse Staff Alias", function (needs) {
   });
 
   test("creating topic", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+    const composerActions = composerActionsDropdown();
 
     await visit("/");
     await click("button#create-topic");
@@ -60,7 +96,7 @@ acceptance("Discourse Staff Alias", function (needs) {
   });
 
   test("creating post", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+    const composerActions = composerActionsDropdown();
 
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .create");
@@ -76,7 +112,7 @@ acceptance("Discourse Staff Alias", function (needs) {
 
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .create");
-    const composerActions = selectKit(".composer-actions");
+    const composerActions = composerActionsDropdown();
     await composerActions.expand();
 
     assert.false(
@@ -87,7 +123,7 @@ acceptance("Discourse Staff Alias", function (needs) {
   testIfPresenceInstalled(
     "uses whisper channel for presence",
     async function (assert) {
-      const composerActions = selectKit(".composer-actions");
+      const composerActions = composerActionsDropdown();
 
       await visit("/t/internationalization-localization/280");
       await click("#topic-footer-buttons .create");
@@ -118,7 +154,7 @@ acceptance("Discourse Staff Alias", function (needs) {
   );
 
   test("editing post", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+    const composerActions = composerActionsDropdown();
 
     await visit("/t/internationalization-localization/280");
     await click("article#post_1 button.show-more-actions");

--- a/test/javascripts/acceptance/staff-alias-composer-test.js
+++ b/test/javascripts/acceptance/staff-alias-composer-test.js
@@ -55,6 +55,7 @@ acceptance("Discourse Staff Alias", function (needs) {
 
   needs.settings({
     enable_whispers: true,
+    enable_new_composer_actions: true,
     staff_alias_enabled: true,
   });
 
@@ -161,10 +162,10 @@ acceptance("Discourse Staff Alias", function (needs) {
     await click("article#post_1 button.edit");
     await composerActions.expand();
 
-    assert.strictEqual(composerActions.rows().length, 2);
+    assert.strictEqual(composerActions.rows().length, 1);
 
     assert.strictEqual(
-      composerActions.rowByIndex(1).value(),
+      composerActions.rowByIndex(0).value(),
       "toggle_reply_as_staff_alias"
     );
   });


### PR DESCRIPTION
The core composer-actions component was rewritten from a select-kit dropdown to a DMenu-based component. This updates the plugin to use the new transformer APIs instead of the select-kit modification API:

- Replace `modifySelectKit("composer-actions")` with `registerValueTransformer("composer-actions-content")`
- Replace `modifyClass("component:composer-actions")` with `registerBehaviorTransformer("composer-actions-on-select")`
- Update tests to use DMenu selectors instead of select-kit helpers

To be merged upon https://github.com/discourse/discourse/pull/38068