### PR TITLE
FIX: Controller aliasing remains active when staff alias is disabled

### DIFF
--- a/lib/discourse_staff_alias/engine.rb
+++ b/lib/discourse_staff_alias/engine.rb
@@ -21,7 +21,7 @@ module DiscourseStaffAlias
   end
 
   def self.user_allowed?(user)
-    return false if user.blank?
+    return false if !enabled? || user.blank?
     user.can_post_as_staff_alias
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -93,6 +93,25 @@ describe PostsController do
                   }.from(false).to(true)
     end
 
+    it "does not allow a staff user to post as alias user when staff alias is disabled" do
+      sign_in(moderator)
+      SiteSetting.set(:staff_alias_enabled, false)
+      alias_user = DiscourseStaffAlias.alias_user
+
+      expect do
+        post "/posts.json",
+             params: {
+               raw: "this is a post",
+               topic_id: post_1.topic_id,
+               reply_to_post_number: 1,
+               as_staff_alias: true,
+             }
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+      end.not_to change { alias_user.posts.count }
+    end
+
     it "allows a staff user to post as alias user" do
       sign_in(moderator)
       alias_user = DiscourseStaffAlias.alias_user
@@ -196,6 +215,25 @@ describe PostsController do
             }.by(-1).and change { DraftSequence.current(moderator, post_1.topic.draft_key) }.from(
                     1,
                   ).to(2)
+    end
+
+    it "does not allow a staff user to edit as alias user when staff alias is disabled" do
+      sign_in(moderator)
+      SiteSetting.set(:staff_alias_enabled, false)
+
+      expect do
+        put "/posts/#{post_1.id}.json",
+            params: {
+              post: {
+                raw: "new raw body",
+                edit_reason: "typo",
+                as_staff_alias: true,
+              },
+            }
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+      end.not_to change { post_1.revisions.count }
     end
 
     it "allows staff user to edit normal posts as alias user" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -54,6 +54,25 @@ describe PostsController do
       expect(DiscourseStaffAlias::UsersPostRevisionsLink.count).to eq(0)
     end
 
+    it "does not allow a staff user to update topic as alias user when staff alias is disabled" do
+      sign_in(moderator)
+      SiteSetting.set(:staff_alias_enabled, false)
+      original_title = topic.title
+
+      expect do
+        put "/t/#{topic.slug}/#{topic.id}.json",
+            params: {
+              title: "brand new title",
+              as_staff_alias: true,
+            }
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+      end.not_to change { post_1.post_revisions.count }
+
+      expect(topic.reload.title).to eq(original_title)
+    end
+
     it "should revise topic title as staff alias user for a topic created by staff alias user" do
       sign_in(user)
       SiteSetting.set(:staff_alias_allowed_groups, "#{Group::AUTO_GROUPS[:staff]}|#{group.id}")


### PR DESCRIPTION
## Summary

Correctly enforce the staff alias feature toggle by preventing users from acting as the alias user when the staff_alias_enabled setting is disabled. This ensures that authorization checks for post and topic operations respect the global feature state.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1420

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>